### PR TITLE
Update ManifoldDiffEq.jl

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.3] - 2025-05-11
+
+### Changed
+
+* Enable ManifoldODESolution to support abstract numeric types (include Complex with previously supported Real)
+
 ## [0.2.2] – 2025-03-25
 
 ### Changed

--- a/src/ManifoldDiffEq.jl
+++ b/src/ManifoldDiffEq.jl
@@ -107,7 +107,7 @@ Fields:
 * `retcode`: [`ReturnCode`](https://docs.sciml.ai/SciMLBase/stable/interfaces/Solutions/#retcodes) of the solution.
 """
 struct ManifoldODESolution{
-    T<:Real,
+    T<:Number,
     uType,
     tType,
     rateType,
@@ -137,7 +137,7 @@ function ManifoldODESolution{T}(
     dense,
     stats,
     retcode,
-) where {T<:Real}
+) where {T<:Number}
     return ManifoldODESolution{
         T,
         typeof(u),
@@ -160,7 +160,7 @@ function ManifoldODESolution{T}(
     )
 end
 
-constructorof(::Type{<:ManifoldODESolution{T}}) where {T<:Real} = ManifoldODESolution{T}
+constructorof(::Type{<:ManifoldODESolution{T}}) where {T<:Number} = ManifoldODESolution{T}
 
 function solution_new_retcode(sol::ManifoldODESolution, retcode)
     return @set sol.retcode = retcode


### PR DESCRIPTION
This change allows solvers to work on complex manifolds.  With the current code, attempting to solve an ODE on complex projective space threw a type exception.  With this change, I can at least get numbers to check.